### PR TITLE
feat!: rename package to @tailorbrands/ember-gtm

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "qs": "^6.13.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Update minimum Node.js version to 18+.

BREAKING CHANGE: Package has been renamed from `ember-gtm` to `@tailorbrands/ember-gtm`. Consumers must update their dependency name in package.json and import paths.