### PR TITLE
fix: resolve @babel/runtime CVE-2025-27789 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "lodash": "^4.17.21",
     "lodash.template": "npm:lodash@^4.17.21",
     "braces": "^3.0.3",
-    "qs": "^6.13.0"
+    "qs": "^6.13.0",
+    "@babel/runtime": "^7.26.10"
   },
   "engines": {
     "node": ">= 18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,19 +1034,10 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@7.12.18":
-  version "7.12.18"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.18.tgz#af137bd7e7d9705a412b3caaf991fe6aaa97831b"
-  integrity sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.8.4":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
-  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
-  dependencies:
-    regenerator-runtime "^0.13.4"
+"@babel/runtime@7.12.18", "@babel/runtime@^7.26.10", "@babel/runtime@^7.8.4":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
 "@babel/template@^7.16.7":
   version "7.16.7"


### PR DESCRIPTION
Add @babel/runtime ^7.26.10 resolution to patch ReDoS vulnerability in named capturing group polyfill (Dependabot alert #101).