### PR TITLE
chore: add CODEOWNERS for .github/workflows/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://docs.github.com/articles/about-codeowners
+/.github/workflows/ @TailorBrands/platform


### PR DESCRIPTION
Adds CODEOWNERS requiring @TailorBrands/platform review on .github/workflows/ changes. Follow-up to MI-X012 (https://trello.com/c/awTAAwEB) — locks in pin enforcement at the review layer.